### PR TITLE
testing script for gpkit-models

### DIFF
--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,65 @@
+"""Script for running all gpkit-models test() methods"""
+import unittest
+from gpkit.tests.helpers import run_tests
+MODULES = []
+
+import beam
+MODULES.append(beam)
+
+import troposphere
+MODULES.append(troposphere)
+import troposphere_sp
+MODULES.append(troposphere_sp)
+
+from aircraft import breguet_range, cost
+MODULES.append(breguet_range)
+MODULES.append(cost)
+
+
+def test_generator(model_class):
+    """Returns method that tests model_class, to be attached to a TestCase"""
+    def test(self):
+        m = model_class()
+        m.test()
+    return test
+
+
+class TestModels(unittest.TestCase):
+    """Single TestCase for all Models in gpkit-models"""
+    pass
+
+
+def attach_tests():
+    """Gather Models that have test() methods; attach to TestModels"""
+    for module in MODULES:
+        for attr_name in dir(module):
+            candidate = getattr(module, attr_name)
+            try:
+                if candidate.__module__ != module.__name__:
+                    # skip things imported by this module, like np
+                    continue
+                if hasattr(candidate, 'test'):
+                    setattr(TestModels,
+                            "test_%s" % candidate.__name__,
+                            test_generator(candidate))
+            except AttributeError:
+                # dict attributes like __builtins__ don't have __module__
+                pass
+
+
+def run(xmloutput=False):
+    """Run all gpkit-models unit tests.
+
+    Arguments
+    ---------
+    xmloutput: bool
+        If true, generate xml output files for continuous integration
+    """
+    if xmloutput:
+        raise NotImplementedError("gpkit-models CI has not yet been set up")
+    attach_tests()
+    run_tests([TestModels])
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
`testing.py` assembles all tests into a TestCase and runs it.

This is ready for review. There are a few remaining issues that I would like @bqpd's help addressing:

 - [ ] There appear to be a number of issues related to me probably doing imports incorrectly. Symptoms:
    - my pep8 complains about relative imports like `import beam`
    - That said, I can't get `from . import beam` to work
    - When I run `from testing import run` or `from testing import beam` in ipython, the beam test appears to execute (it shouldn't run the test when I only import). I can't figure out why.
    - When I run `testing.py`, only 4 tests run, not 5 (beam is missing)
    - Semi-unrelated import question: should there be an `__init__.py` in `aircraft`?

 - [ ] Test for all solvers?
    - currently, `testing.py` only runs the `test()` method for the default solver. Should we test for all solvers like in GPkit?

 - [ ] verbosity control
    - Currently running `testing.py` results in a lot of verbose printout. We need a good way to eliminate this (and recommendations for how future `test()` methods should handle printing