### PR TITLE
adding D8 to tests

### DIFF
--- a/EXTERNALTESTS
+++ b/EXTERNALTESTS
@@ -2,3 +2,4 @@ shopping
 jho
 turbofan
 gas_solar_trade
+d8


### PR DESCRIPTION
D8 should be in tests because it passed until https://github.com/hoburg/d8/issues/65